### PR TITLE
Preserve namespace and keywordize

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -15,5 +15,6 @@
             [lein-cloverage "1.1.2"]]
   :profiles {:uberjar {:aot :all}
              :dev {:dependencies [[clj-kondo "RELEASE"]
-                                  [org.clojure/clojure "1.10.1"]]
+                                  [org.clojure/clojure "1.10.0"]
+                                  [org.clojure/test.check "0.10.0"]]
                    :aliases {"clj-kondo" ["run" "-m" "clj-kondo.main"]}}})

--- a/project.clj
+++ b/project.clj
@@ -15,6 +15,6 @@
             [lein-cloverage "1.1.2"]]
   :profiles {:uberjar {:aot :all}
              :dev {:dependencies [[clj-kondo "RELEASE"]
-                                  [org.clojure/clojure "1.10.0"]
+                                  [org.clojure/clojure "1.10.1"]
                                   [org.clojure/test.check "0.10.0"]]
                    :aliases {"clj-kondo" ["run" "-m" "clj-kondo.main"]}}})

--- a/src/dandelion/core.clj
+++ b/src/dandelion/core.clj
@@ -29,22 +29,22 @@
     (.makeReadOnly value)
     value))
 
-(defn clj->ion-binary
-  "Transforms a Clojure value to a byte array of Ion binary"
-  [clj-value]
-  (with-open [os (ByteArrayOutputStream.)
-              writer (.build (IonBinaryWriterBuilder/standard) os)
-              reader (.build (IonReaderBuilder/standard) (json/write-str clj-value))]
-    (.writeValues writer reader)
-    (.finish writer)
-    (.toByteArray os)))
-
 (defn clj->ion
   "Transforms a Clojure value, usually a Map to an immutable IonValue."
   [clj-value]
   (-> clj-value
       (json/write-str :key-fn preserve-ns)
       json->ion))
+
+(defn clj->ion-binary
+  "Transforms a Clojure value to a byte array of Ion binary"
+  [clj-value]
+  (let [ion-value (clj->ion clj-value)]
+    (with-open [os (ByteArrayOutputStream.)
+                writer (.build (IonBinaryWriterBuilder/standard) os)]
+      (.writeTo ion-value writer)
+      (.finish writer)
+      (.toByteArray os))))
 
 (defn ion->clj
   "Transforms a IonValue to a Clojure value"

--- a/src/dandelion/core.clj
+++ b/src/dandelion/core.clj
@@ -48,7 +48,9 @@
 
 (defn ion->clj
   "Transforms a IonValue to a Clojure value"
-  [ion-value]
-  (-> ion-value
-      ion->json
-      json/read-str))
+  ([ion-value]
+   (ion->clj ion-value false))
+  ([ion-value keywordize?]
+   (-> ion-value
+       ion->json
+       (json/read-str :key-fn (if keywordize? keyword identity)))))

--- a/src/dandelion/core.clj
+++ b/src/dandelion/core.clj
@@ -7,6 +7,11 @@
             IonTextWriterBuilder]
            java.io.ByteArrayOutputStream))
 
+(defn- preserve-ns [key]
+  (if (keyword? key)
+    (if-let [namespace (namespace key)] (str namespace "/" (name key)) (name key))
+    (str key)))
+
 (defn ion->json
   "Transforms an IonValue to a JSON value serialised as String."
   [ion-value]
@@ -38,7 +43,7 @@
   "Transforms a Clojure value, usually a Map to an immutable IonValue."
   [clj-value]
   (-> clj-value
-      json/write-str
+      (json/write-str :key-fn preserve-ns)
       json->ion))
 
 (defn ion->clj

--- a/test/dandelion/core_test.clj
+++ b/test/dandelion/core_test.clj
@@ -1,29 +1,25 @@
 (ns dandelion.core-test
   (:require [clojure.test :as t]
-            [dandelion.core :refer [clj->ion ion->clj clj->ion-binary]])
-  (:import (com.amazon.ion IonType)))
+            [clojure.test.check.clojure-test :refer [defspec]]
+            [clojure.test.check.generators :as gen]
+            [clojure.test.check.properties :as prop]
+            [dandelion.core :refer [clj->ion ion->clj]]))
 
-(def sample-data {"text" "some text"
-                  "number" 1234
-                  "array" [1, 2, 3, 4]
-                  "obj" {"more-array" [5, 6, 7]
-                         "more-number" 789.3}
-                  "bool" true
-                  "null" nil})
+(def simple-type-gen
+  (gen/one-of [gen/int
+               gen/size-bounded-bigint
+               (gen/double* {:infinite? false :NaN? false})
+               gen/string
+               gen/boolean]))
 
-(t/deftest dandelion-test
-  (t/testing "Transformation"
-    (t/testing "Clojure to Ion"
-      (let [ion (clj->ion sample-data)]
-        (t/is (= (.getType ion) IonType/STRUCT) "Type should be STRUCT")
+(defn container-type
+  [inner-type]
+  (gen/one-of [(gen/vector inner-type)
+           ;; scaling this by half since it naturally generates twice
+           ;; as many elements
+           (gen/scale #(quot % 2)
+                  (gen/map (gen/one-of [gen/keyword gen/keyword-ns]) inner-type))]))
 
-        (doseq [key (keys sample-data)]
-          (t/is (.containsKey ion key) (str "Key " key " was not found"))))))
-
-  (t/testing "Ion to Clojure"
-    (let [ion (clj->ion sample-data)]
-      (t/is (= (ion->clj ion) sample-data))))
-
-  (t/testing "Ion binary to Clojure"
-    (let [ion-binary (clj->ion-binary sample-data)]
-      (t/is (= (ion->clj ion-binary) sample-data)))))
+(defspec round-trip 100
+  (prop/for-all [v (gen/recursive-gen container-type simple-type-gen)]
+                (t/is (= v (-> v clj->ion (ion->clj true))))))


### PR DESCRIPTION
If keyword namespaces are not preserved when converting a Clojure map to JSON, you might end up with duplicate keys in the JSON object which breaks QLDB.